### PR TITLE
Remove mmcv version check

### DIFF
--- a/pyskl/__init__.py
+++ b/pyskl/__init__.py
@@ -1,16 +1,13 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from packaging.version import parse as parse_version
+import warnings
 
 try:
-    import mmcv
-    _mmcv_version = parse_version(mmcv.__version__)
-    if _mmcv_version < parse_version('1.3.6'):
-        raise RuntimeError(
-            f'MMCV>="1.3.6" is required, but {mmcv.__version__} is installed')
+    import mmcv  # type: ignore
 except ImportError:
+    warnings.warn('mmcv is not installed; some functions may be unavailable.',
+                  ImportWarning)
     mmcv = None
 
 from .version import __version__
-
 
 __all__ = ['__version__']


### PR DESCRIPTION
## Summary
- remove strict mmcv version check in `pyskl/__init__.py`
- issue a warning if mmcv is missing

## Testing
- `isort pyskl/__init__.py`