### PR TITLE
Implement collect_env without mmcv

### DIFF
--- a/pyskl/utils/collect_env.py
+++ b/pyskl/utils/collect_env.py
@@ -1,14 +1,67 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from mmcv.utils import collect_env as collect_basic_env
-from mmcv.utils import get_git_hash
+"""Utilities to gather environment information without relying on MMCV."""
+
+import platform
+import subprocess
+import sys
+import torch
+from collections import OrderedDict
 
 import pyskl
 
 
+def get_git_hash(digits=7):
+    """Get the git hash of the current repo.
+
+    Args:
+        digits (int): The number of digits of the hash string. Defaults to 7.
+
+    Returns:
+        str: Git commit hash of specified length. ``"unknown"`` if failed.
+    """
+
+    cmd = ["git", "rev-parse", "HEAD"]
+    try:
+        sha = subprocess.check_output(cmd, stderr=subprocess.DEVNULL)
+        sha = sha.decode("ascii").strip()
+    except Exception:
+        sha = "unknown"
+    if digits and digits > 0:
+        sha = sha[:digits]
+    return sha
+
+
 def collect_env():
-    env_info = collect_basic_env()
-    env_info['pyskl'] = (
-        pyskl.__version__ + '+' + get_git_hash(digits=7))
+    """Collect the environment information."""
+
+    env_info = OrderedDict()
+    env_info["sys.platform"] = platform.platform()
+    env_info["Python"] = sys.version.replace("\n", "")
+    env_info["CUDA available"] = torch.cuda.is_available()
+    env_info["pyskl"] = pyskl.__version__ + "+" + get_git_hash(digits=7)
+
+    # PyTorch and CUDA related info
+    env_info["PyTorch"] = torch.__version__
+    try:
+        env_info["PyTorch compiling GPU"] = torch.version.cuda
+    except AttributeError:
+        env_info["PyTorch compiling GPU"] = "None"
+
+    if env_info["CUDA available"]:
+        env_info["GPU"] = ", ".join(
+            [torch.cuda.get_device_name(i) for i in range(torch.cuda.device_count())]
+        )
+        try:
+            from torch.utils.cpp_extension import CUDA_HOME
+            env_info["CUDA_HOME"] = str(CUDA_HOME)
+        except Exception:
+            env_info["CUDA_HOME"] = "Not Available"
+        try:
+            nvcc_out = subprocess.check_output(["nvcc", "--version"])
+            nvcc_out = nvcc_out.decode("utf-8").strip().split("\n")[-1]
+            env_info["NVCC"] = nvcc_out
+        except Exception:
+            env_info["NVCC"] = "Not Available"
     return env_info
 
 

--- a/tools/train.py
+++ b/tools/train.py
@@ -10,13 +10,13 @@ import torch.distributed as dist
 from mmcv import Config
 from mmcv import digit_version as dv
 from mmcv.runner import get_dist_info, init_dist, set_random_seed
-from mmcv.utils import get_git_hash
 
 from pyskl import __version__
 from pyskl.apis import init_random_seed, train_model
 from pyskl.datasets import build_dataset
 from pyskl.models import build_model
 from pyskl.utils import collect_env, get_root_logger, mc_off, mc_on, test_port
+from pyskl.utils.collect_env import get_git_hash
 
 
 def parse_args():


### PR DESCRIPTION
## Summary
- remove mmcv from utils.collect_env
- provide lightweight `get_git_hash`
- rework train script to use new helpers

## Testing
- `isort --check-only pyskl/utils/collect_env.py tools/train.py`
- `python -m py_compile pyskl/utils/collect_env.py tools/train.py`
