### PR TITLE
Remove mmcv dependencies from training/test

### DIFF
--- a/pyskl/apis/__init__.py
+++ b/pyskl/apis/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from mmcv.engine import multi_gpu_test, single_gpu_test
+from .testing import multi_gpu_test, single_gpu_test
 
 from .inference import inference_recognizer, init_recognizer
 from .train import init_random_seed, train_model

--- a/pyskl/apis/testing.py
+++ b/pyskl/apis/testing.py
@@ -1,0 +1,55 @@
+import os
+import os.path as osp
+import shutil
+import tempfile
+import torch
+import torch.distributed as dist
+
+from ..utils import get_dist_info, load as _load, dump as _dump
+
+
+def collect_results(result_part, size, tmpdir=None):
+    rank, world_size = get_dist_info()
+    if world_size == 1:
+        return result_part[:size]
+
+    if tmpdir is None:
+        tmpdir = tempfile.mkdtemp()
+    else:
+        os.makedirs(tmpdir, exist_ok=True)
+    part_file = osp.join(tmpdir, f'part_{rank}.pkl')
+    _dump(result_part, part_file)
+    dist.barrier()
+
+    if rank == 0:
+        part_list = []
+        for i in range(world_size):
+            part_file = osp.join(tmpdir, f'part_{i}.pkl')
+            part_list.extend(_load(part_file))
+        part_list = part_list[:size]
+        shutil.rmtree(tmpdir)
+        return part_list
+    else:
+        return None
+
+
+def single_gpu_test(model, data_loader):
+    model.eval()
+    results = []
+    for data in data_loader:
+        with torch.no_grad():
+            result = model(return_loss=False, **data)
+        results.append(result)
+    return results
+
+
+def multi_gpu_test(model, data_loader, tmpdir=None):
+    model.eval()
+    results = []
+    rank, _ = get_dist_info()
+    for data in data_loader:
+        with torch.no_grad():
+            result = model(return_loss=False, **data)
+        results.append(result)
+    results = collect_results(results, len(data_loader.dataset), tmpdir)
+    return results

--- a/tools/train.py
+++ b/tools/train.py
@@ -1,16 +1,13 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 # flake8: noqa: E722
 import argparse
-import mmcv
 import os
 import os.path as osp
 import time
 import torch
 import torch.distributed as dist
-from mmcv import Config
-from mmcv import digit_version as dv
-from mmcv.runner import get_dist_info, init_dist, set_random_seed
-from mmcv.utils import get_git_hash
+from pyskl.utils import (Config, digit_version as dv, get_dist_info, init_dist,
+                        set_random_seed, get_git_hash)
 
 from pyskl import __version__
 from pyskl.apis import init_random_seed, train_model
@@ -86,7 +83,7 @@ def main():
             cfg.resume_from = resume_pth
 
     # create work_dir
-    mmcv.mkdir_or_exist(osp.abspath(cfg.work_dir))
+    os.makedirs(osp.abspath(cfg.work_dir), exist_ok=True)
     # dump config
     cfg.dump(osp.join(cfg.work_dir, osp.basename(args.config)))
     # init logger before other steps


### PR DESCRIPTION
## Summary
- drop mmcv from tools and training API
- implement lightweight replacements for test utilities and runner logic
- add helper utilities for distributed setup and checkpoint handling

## Testing
- `python -m py_compile tools/train.py tools/test.py pyskl/apis/train.py pyskl/apis/testing.py pyskl/utils/misc.py pyskl/apis/__init__.py`