### PR TITLE
Make mmcv-full optional

### DIFF
--- a/pyskl.yaml
+++ b/pyskl.yaml
@@ -93,7 +93,7 @@ dependencies:
     - kiwisolver==1.4.4
     - matplotlib==3.5.3
     - matplotlib-inline==0.1.6
-    - https://download.openmmlab.com/mmcv/dist/cu113/torch1.11.0/mmcv_full-1.5.0-cp37-cp37m-manylinux1_x86_64.whl
+    # mmcv-full is optional; install it manually if needed
     - mmdet==2.23.0
     - mmpose==0.24.0
     - moviepy==1.0.3

--- a/pyskl_310.yaml
+++ b/pyskl_310.yaml
@@ -93,7 +93,7 @@ dependencies:
     - kiwisolver==1.4.4
     - matplotlib==3.6.3
     - matplotlib-inline==0.1.6
-    - mmcv-full==1.7.0
+    # mmcv-full is optional; install it manually if needed
     - mmdet==2.25.1
     - mmpose==0.29.0
     - moviepy==1.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 decord>=0.6.0
 fvcore
 matplotlib
-# mmcv is optional; install mmcv-full manually if needed
+# mmcv is optional; install mmcv or mmcv-full manually if needed
 mmdet==2.23.0
 mmpose==0.24.0
 moviepy


### PR DESCRIPTION
## Summary
- remove explicit mmcv-full wheel from `pyskl.yaml`
- remove mmcv-full pin from `pyskl_310.yaml`
- clarify that mmcv or mmcv-full is optional in `requirements.txt`

## Testing
- `pre-commit` *(fails: `pre-commit` not installed)*