### PR TITLE
Remove mmcv imports

### DIFF
--- a/pyskl/__init__.py
+++ b/pyskl/__init__.py
@@ -1,12 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import warnings
-
-try:
-    import mmcv  # type: ignore
-except ImportError:
-    warnings.warn('mmcv is not installed; some functions may be unavailable.',
-                  ImportWarning)
-    mmcv = None
+"""pyskl package initialization."""
 
 from .version import __version__
 

--- a/pyskl/core/evaluation.py
+++ b/pyskl/core/evaluation.py
@@ -1,6 +1,22 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import numpy as np
-from mmcv.runner import DistEvalHook as BasicDistEvalHook
+
+try:  # optional dependency
+    from mmcv.runner import DistEvalHook as BasicDistEvalHook  # type: ignore
+except Exception:  # pragma: no cover - mmcv not installed
+    class BasicDistEvalHook:
+        def __init__(self, *args, interval=1, by_epoch=True, start=None, **kwargs):
+            self.interval = interval
+            self.by_epoch = by_epoch
+            self.start = start
+
+        def every_n_epochs(self, runner, n):
+            return (runner.epoch + 1) % n == 0
+
+        def _should_evaluate(self, runner):
+            if self.start is not None and (runner.epoch + 1) < self.start:
+                return False
+            return self.every_n_epochs(runner, self.interval)
 
 
 class DistEvalHook(BasicDistEvalHook):

--- a/pyskl/utils/visualize.py
+++ b/pyskl/utils/visualize.py
@@ -5,7 +5,7 @@ import moviepy.editor as mpy
 import mpl_toolkits.mplot3d.axes3d as p3
 import numpy as np
 from matplotlib.animation import FuncAnimation
-from mmcv import load
+from .misc import load
 from tqdm import tqdm
 
 from pyskl.smp import h2r

--- a/tools/data/ntu_preproc.py
+++ b/tools/data/ntu_preproc.py
@@ -3,7 +3,7 @@ import multiprocessing as mp
 import numpy as np
 import os
 import os.path as osp
-from mmcv import dump
+from pyskl.utils import dump
 from tqdm import tqdm
 
 from pyskl.smp import mrlines


### PR DESCRIPTION
## Summary
- fallback to built-in functions when mmcv is unavailable
- use our `Config`, `load` and `dump` helpers instead of mmcv
- drop mmcv import from package init

## Testing
- `python -m py_compile pyskl/apis/inference.py pyskl/utils/visualize.py tools/data/ntu_preproc.py pyskl/__init__.py pyskl/core/evaluation.py`