### PR TITLE
Remove mmcv dependency

### DIFF
--- a/pyskl/core/evaluation.py
+++ b/pyskl/core/evaluation.py
@@ -1,22 +1,23 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import numpy as np
 
-try:  # optional dependency
-    from mmcv.runner import DistEvalHook as BasicDistEvalHook  # type: ignore
-except Exception:  # pragma: no cover - mmcv not installed
-    class BasicDistEvalHook:
-        def __init__(self, *args, interval=1, by_epoch=True, start=None, **kwargs):
-            self.interval = interval
-            self.by_epoch = by_epoch
-            self.start = start
 
-        def every_n_epochs(self, runner, n):
-            return (runner.epoch + 1) % n == 0
+class BasicDistEvalHook:
+    """A minimal substitute for ``mmcv.runner.DistEvalHook``."""
 
-        def _should_evaluate(self, runner):
-            if self.start is not None and (runner.epoch + 1) < self.start:
-                return False
-            return self.every_n_epochs(runner, self.interval)
+    def __init__(self, *args, interval=1, by_epoch=True, start=None, save_best=None, **kwargs):
+        self.interval = interval
+        self.by_epoch = by_epoch
+        self.start = start
+        self.save_best = save_best
+
+    def every_n_epochs(self, runner, n):
+        return (runner.epoch + 1) % n == 0
+
+    def _should_evaluate(self, runner):
+        if self.start is not None and (runner.epoch + 1) < self.start:
+            return False
+        return self.every_n_epochs(runner, self.interval)
 
 
 class DistEvalHook(BasicDistEvalHook):

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,6 @@ line_length = 119
 multi_line_output = 0
 known_standard_library = pkg_resources,setuptools
 known_first_party = pyskl
-known_third_party = cv2,decord,fvcore,matplotlib,mmcv,moviepy,numpy,requests,scipy,torch,tqdm
+known_third_party = cv2,decord,fvcore,matplotlib,moviepy,numpy,requests,scipy,torch,tqdm
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY

--- a/setup.py
+++ b/setup.py
@@ -125,5 +125,4 @@ if __name__ == '__main__':
         url='https://github.com/kennymckormick/pyskl',
         license='Apache License 2.0',
         install_requires=parse_requirements('requirements.txt'),
-        extras_require={'mmcv': ['mmcv-full']},
         zip_safe=False)


### PR DESCRIPTION
## Summary
- stop importing mmcv and use local helpers instead
- implement a small DistEvalHook replacement
- drop the mmcv extras from setup
- update isort configuration

## Testing
- `pre-commit` *(fails: command not found)*