### PR TITLE
Reduce mmcv dependency

### DIFF
--- a/demo/demo.md
+++ b/demo/demo.md
@@ -4,7 +4,7 @@ We currently provide an offline GPU-demo for skeleton action recognition and an 
 
 ## Preparation
 
-- Before running the skeleton action recognition demo, make sure you have installed `mmcv-full`, `mmpose` and `mmdet`. We recommend you to directly use the provided conda environment, with all necessary dependencies included:
+- Before running the skeleton action recognition demo, make sure you have installed `mmpose` and `mmdet`. We recommend you to directly use the provided conda environment, with all necessary dependencies included:
 ```bash
 # Following commands assume you are in the root directory of pyskl (indicated as `$PYSKL`)
 # This command runs well with conda 22.9.0, if you are running an early conda version and got some errors, try to update your conda first

--- a/demo/demo_skeleton.py
+++ b/demo/demo_skeleton.py
@@ -151,8 +151,9 @@ def detection_inference(args, frame_paths):
         list[np.ndarray]: The human detection results.
     """
     model = init_detector(args.det_config, args.det_checkpoint, args.device)
-    assert model is not None, ('Failed to build the detection model. Check if you have installed mmcv-full properly. '
-                               'You should first install mmcv-full successfully, then install mmdet, mmpose. ')
+    assert model is not None, (
+        'Failed to build the detection model. Make sure mmdet and mmpose are correctly installed.'
+    )
     assert model.CLASSES[0] == 'person', 'We require you to use a detector trained on COCO'
     results = []
     print('Performing Human Detection for each frame')

--- a/pyskl.yaml
+++ b/pyskl.yaml
@@ -93,7 +93,7 @@ dependencies:
     - kiwisolver==1.4.4
     - matplotlib==3.5.3
     - matplotlib-inline==0.1.6
-    # mmcv-full is optional; install it manually if needed
+    # mmcv-full is optional; install it only when using detection or pose modules
     - mmdet==2.23.0
     - mmpose==0.24.0
     - moviepy==1.0.3

--- a/pyskl/apis/inference.py
+++ b/pyskl/apis/inference.py
@@ -8,31 +8,27 @@ import warnings
 from collections.abc import Mapping, Sequence
 from torch.utils.data._utils.collate import default_collate
 
-try:  # optional dependency
-    from mmcv.parallel import collate, scatter  # type: ignore
-except Exception:  # pragma: no cover - mmcv not installed
-    def collate(batch, samples_per_gpu=1):
-        return default_collate(batch)
 
-    def scatter(inputs, devices):
-        assert len(devices) == 1
-        device = devices[0]
+def collate(batch, samples_per_gpu=1):
+    return default_collate(batch)
 
-        def _scatter(obj):
-            if isinstance(obj, torch.Tensor):
-                return obj.to(device)
-            if isinstance(obj, Mapping):
-                return {k: _scatter(v) for k, v in obj.items()}
-            if isinstance(obj, Sequence) and not isinstance(obj, (str, bytes)):
-                return type(obj)(_scatter(v) for v in obj)
-            return obj
 
-        return [_scatter(inputs)]
+def scatter(inputs, devices):
+    assert len(devices) == 1
+    device = devices[0]
 
-try:
-    from mmcv.runner import load_checkpoint  # type: ignore
-except Exception:  # pragma: no cover - mmcv not installed
-    from pyskl.utils import load_checkpoint
+    def _scatter(obj):
+        if isinstance(obj, torch.Tensor):
+            return obj.to(device)
+        if isinstance(obj, Mapping):
+            return {k: _scatter(v) for k, v in obj.items()}
+        if isinstance(obj, Sequence) and not isinstance(obj, (str, bytes)):
+            return type(obj)(_scatter(v) for v in obj)
+        return obj
+
+    return [_scatter(inputs)]
+
+from pyskl.utils import load_checkpoint
 from operator import itemgetter
 
 from pyskl.core import OutputHook

--- a/pyskl/core/evaluation.py
+++ b/pyskl/core/evaluation.py
@@ -1,22 +1,20 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import numpy as np
 
-try:  # optional dependency
-    from mmcv.runner import DistEvalHook as BasicDistEvalHook  # type: ignore
-except Exception:  # pragma: no cover - mmcv not installed
-    class BasicDistEvalHook:
-        def __init__(self, *args, interval=1, by_epoch=True, start=None, **kwargs):
-            self.interval = interval
-            self.by_epoch = by_epoch
-            self.start = start
 
-        def every_n_epochs(self, runner, n):
-            return (runner.epoch + 1) % n == 0
+class BasicDistEvalHook:
+    def __init__(self, *args, interval=1, by_epoch=True, start=None, **kwargs):
+        self.interval = interval
+        self.by_epoch = by_epoch
+        self.start = start
 
-        def _should_evaluate(self, runner):
-            if self.start is not None and (runner.epoch + 1) < self.start:
-                return False
-            return self.every_n_epochs(runner, self.interval)
+    def every_n_epochs(self, runner, n):
+        return (runner.epoch + 1) % n == 0
+
+    def _should_evaluate(self, runner):
+        if self.start is not None and (runner.epoch + 1) < self.start:
+            return False
+        return self.every_n_epochs(runner, self.interval)
 
 
 class DistEvalHook(BasicDistEvalHook):

--- a/pyskl_310.yaml
+++ b/pyskl_310.yaml
@@ -93,7 +93,7 @@ dependencies:
     - kiwisolver==1.4.4
     - matplotlib==3.6.3
     - matplotlib-inline==0.1.6
-    # mmcv-full is optional; install it manually if needed
+    # mmcv-full is optional; install it only when using detection or pose modules
     - mmdet==2.25.1
     - mmpose==0.29.0
     - moviepy==1.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 decord>=0.6.0
 fvcore
 matplotlib
-# mmcv is optional; install mmcv or mmcv-full manually if needed
+# mmcv is optional; install it only if using detection or pose modules
 mmdet==2.23.0
 mmpose==0.24.0
 moviepy

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,6 @@ line_length = 119
 multi_line_output = 0
 known_standard_library = pkg_resources,setuptools
 known_first_party = pyskl
-known_third_party = cv2,decord,fvcore,matplotlib,mmcv,moviepy,numpy,requests,scipy,torch,tqdm
+known_third_party = cv2,decord,fvcore,matplotlib,moviepy,numpy,requests,scipy,torch,tqdm
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY

--- a/setup.py
+++ b/setup.py
@@ -125,5 +125,4 @@ if __name__ == '__main__':
         url='https://github.com/kennymckormick/pyskl',
         license='Apache License 2.0',
         install_requires=parse_requirements('requirements.txt'),
-        extras_require={'mmcv': ['mmcv-full']},
         zip_safe=False)


### PR DESCRIPTION
## Summary
- drop optional imports from mmcv
- simplify skeleton demo's dependency notes
- clarify optional mmcv use in requirements and env files
- remove mmcv from setup extras and style config

## Testing
- `python -m py_compile pyskl/apis/inference.py pyskl/core/evaluation.py demo/demo_skeleton.py`